### PR TITLE
Split into subspecs

### DIFF
--- a/DRYUtilities.podspec
+++ b/DRYUtilities.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "DRYUtilities"
-  s.version          = "1.5.0"
+  s.version          = "1.5.1"
   s.summary          = "DRYUtilities provides common utilities used in projects by AppFoundry"
   s.homepage         = "https://github.com/appfoundry/DRYUtilities"
   s.license          = 'MIT'
@@ -19,12 +19,36 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, '7.0'
   s.requires_arc = true
+  
+  s.subspec 'Configuration' do |ss|
+    ss.source_files = 'Pod/Classes/Configuration/**/*'
+  end
 
-  s.source_files = 'Pod/Classes/**/*'
+  s.subspec 'CoreData' do |ss|
+    ss.source_files = 'Pod/Classes/CoreData/**/*'
+    ss.weak_framework = 'CoreData'
+  end
+
+  s.subspec 'Foundation' do |ss|
+    ss.source_files = 'Pod/Classes/Foundation/**/*'
+  end
+
+  s.subspec 'Networking' do |ss|
+    ss.source_files = 'Pod/Classes/Networking/**/*'
+  end
+
+  s.subspec 'Security' do |ss|
+    ss.source_files = 'Pod/Classes/Security/**/*'
+  end
+
+  s.subspec 'UIKit' do |ss|
+    ss.source_files = 'Pod/Classes/UIKit/**/*'
+    ss.weak_framework = 'UIKit'
+  end
+
   s.resource_bundles = {
     'DRYUtilities' => ['Pod/Assets/*.png']
   }
 
   s.frameworks = 'Foundation'
-  s.weak_frameworks = 'UIKit', 'CoreData'
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,19 @@
 PODS:
-  - DRYUtilities (1.5.0)
-  - OCHamcrest (4.2.0)
-  - OCMockito (1.4.0):
+  - DRYUtilities (1.5.1):
+    - DRYUtilities/Configuration (= 1.5.1)
+    - DRYUtilities/CoreData (= 1.5.1)
+    - DRYUtilities/Foundation (= 1.5.1)
+    - DRYUtilities/Networking (= 1.5.1)
+    - DRYUtilities/Security (= 1.5.1)
+    - DRYUtilities/UIKit (= 1.5.1)
+  - DRYUtilities/Configuration (1.5.1)
+  - DRYUtilities/CoreData (1.5.1)
+  - DRYUtilities/Foundation (1.5.1)
+  - DRYUtilities/Networking (1.5.1)
+  - DRYUtilities/Security (1.5.1)
+  - DRYUtilities/UIKit (1.5.1)
+  - OCHamcrest (4.3.0)
+  - OCMockito (2.0.1):
     - OCHamcrest (~> 4.0)
 
 DEPENDENCIES:
@@ -14,8 +26,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  DRYUtilities: 920ec1941e1bfba6726d5b2546aebc94adeb4930
-  OCHamcrest: c14c0b3f4c4e99363e5b87d97bae38c4438b6d5d
-  OCMockito: 4981140c9a9ec06c31af40f636e3c0f25f27e6b2
+  DRYUtilities: d71243d263cb86d7afae18c9f30e3fc3b5c7ba6d
+  OCHamcrest: cd63d27f48a266d4412c0b295b01b8f0940efa81
+  OCMockito: f92ad4c6fac2841a88558879cfe517c40aebf91e
 
 COCOAPODS: 0.39.0


### PR DESCRIPTION
Using subspecs allows library users to pick and choose more granularly.
The entire library therefore doesn’t need to be loaded if that is not
required.
